### PR TITLE
OS X fixes

### DIFF
--- a/_build.sh
+++ b/_build.sh
@@ -5,12 +5,17 @@ DYLIB_EXT="so"
 #FIXME: Find a more idiomatic way to detect the OS.
 if [[ $OSTYPE =~ .*darwin.* ]] ; then DYLIB_EXT="dylib"; fi
 
+# Use clang++-3.8 explicitly, if available. Fall back on available clang++
+# otherwise.
+CLANG=clang++-3.8
+which ${CLANG} > /dev/null || CLANG=clang++
+
 ./generate.py $INPUT templates output || exit 1
 cp $INPUT output/
 
 pushd output > /dev/null
 INPUT_FILE=$(basename $INPUT)
 OUTPUT=${INPUT_FILE%.h}
-clang++-3.8 -fvisibility=hidden -g -std=c++14 -shared -Wl, -o lib${OUTPUT}_c.${DYLIB_EXT} -fPIC ${OUTPUT}_c.cpp || exit 1
+${CLANG} -fvisibility=hidden -g -std=c++14 -shared -Wl, -o lib${OUTPUT}_c.${DYLIB_EXT} -fPIC ${OUTPUT}_c.cpp || exit 1
 strip -x lib${OUTPUT}_c.${DYLIB_EXT}
 popd > /dev/null

--- a/generate.py
+++ b/generate.py
@@ -12,6 +12,12 @@ import HTMLParser
 import annotations
 html_parser = HTMLParser.HTMLParser()
 
+if sys.platform == 'darwin':
+    # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
+    # enabled. Set the library path for libclang manually.
+    clang.cindex.Config.set_library_path(
+        '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib')
+
 if not django.conf.settings.configured :
     django.conf.settings.configure(
             INSTALLED_APPS=('django_apps',),

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ set -e
 export PYTHONPATH=$(pwd)/externals/clang_cpp_code_model
 export PYTHONPATH=$(pwd)/output:$PYTHONPATH
 
-export LD_LIBRARY_PATH="$(pwd)/output:${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="$(pwd)/output:${LD_LIBRARY_PATH:-}"
 
 echo -n Cleaning output
 rm -rf output

--- a/tests/test_asset_bindings.py
+++ b/tests/test_asset_bindings.py
@@ -1,4 +1,13 @@
 from Asset import *
+import os
+import sys
+
+if sys.platform == 'darwin':
+    # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
+    # enabled. Set the library path manually.
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    output_dir = script_dir + '/../output'
+    Config.set_library_path(output_dir)
 
 def test_no_argument_constructor():
     # Lack of exception is all we need to test.

--- a/tests/test_shape_python_bindings.py
+++ b/tests/test_shape_python_bindings.py
@@ -4,6 +4,13 @@ import math
 import nose
 import Shape
 
+if sys.platform == 'darwin':
+    # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
+    # enabled. Set the library path manually.
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    output_dir = script_dir + '/../output'
+    Shape.Config.set_library_path(output_dir)
+
 def test_Shape_Circle_is_called_Circle():
     c = Shape.Circle(3)
     assert c.name() == "Circle"

--- a/tests/test_tree_python_bindings.py
+++ b/tests/test_tree_python_bindings.py
@@ -1,4 +1,13 @@
 from Tree import *
+import os
+import sys
+
+if sys.platform == 'darwin':
+    # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
+    # enabled. Set the library path manually.
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    output_dir = script_dir + '/../output'
+    Config.set_library_path(output_dir)
 
 def test_root_node_is_non_null():
     t = Tree(2)


### PR DESCRIPTION
Various changes to permit the generation to work more easily on a regular OS X system (i.e. one with Xcode, and the various necessary Python packages, but not necessarily with a custom clang build).

- Use clang++ if clang++-3.8 cannot be found.
- Avoid various (DY)LD_LIBRARY_PATH issues when System Integrity Protection (SIP) is enabled.
- Avoid uninitialised variable usage in run_tests.sh causing script termination.