### PR TITLE
Refactor setting of dynamic library path in test files.

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+def set_library_path(config, platforms = ['darwin'], path = None):
+    '''
+    Calls config.set_library_path(path) if the current platform is one of the
+    listed platforms. If the path is not set, it defaults to ../output,
+    relative to the tests directory (i.e. the one containing this file).
+    '''
+    if sys.platform in platforms:
+        if path is None:
+            path = os.path.dirname(os.path.realpath(__file__)) + '/../output'
+        config.set_library_path(path)

--- a/tests/test_asset_bindings.py
+++ b/tests/test_asset_bindings.py
@@ -1,13 +1,7 @@
 from Asset import *
-import os
-import sys
+import common
 
-if sys.platform == 'darwin':
-    # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
-    # enabled. Set the library path manually.
-    script_dir = os.path.dirname(os.path.realpath(__file__))
-    output_dir = script_dir + '/../output'
-    Config.set_library_path(output_dir)
+common.set_library_path(Config)
 
 def test_no_argument_constructor():
     # Lack of exception is all we need to test.

--- a/tests/test_shape_python_bindings.py
+++ b/tests/test_shape_python_bindings.py
@@ -1,15 +1,9 @@
-import sys
-import os
+import common
 import math
 import nose
 import Shape
 
-if sys.platform == 'darwin':
-    # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
-    # enabled. Set the library path manually.
-    script_dir = os.path.dirname(os.path.realpath(__file__))
-    output_dir = script_dir + '/../output'
-    Shape.Config.set_library_path(output_dir)
+common.set_library_path(Shape.Config)
 
 def test_Shape_Circle_is_called_Circle():
     c = Shape.Circle(3)

--- a/tests/test_tree_python_bindings.py
+++ b/tests/test_tree_python_bindings.py
@@ -1,13 +1,7 @@
 from Tree import *
-import os
-import sys
+import common
 
-if sys.platform == 'darwin':
-    # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
-    # enabled. Set the library path manually.
-    script_dir = os.path.dirname(os.path.realpath(__file__))
-    output_dir = script_dir + '/../output'
-    Config.set_library_path(output_dir)
+common.set_library_path(Config)
 
 def test_root_node_is_non_null():
     t = Tree(2)


### PR DESCRIPTION
Each Python test file contained duplicate code for detecting the OS X
platform and setting the dynamic library load path to include ../output.
This code has been moved into common.py as a function
set_library_path(config, platforms, path) where both platforms and path
have defaults.

The test files have been modified to use this function rather than
replicating code.