### PR TITLE
Give Ruby ffi multiple paths to find the dynamic library.

### DIFF
--- a/templates/rb.tmpl
+++ b/templates/rb.tmpl
@@ -2,7 +2,9 @@
 
 module {{class.name}}_c
   extend FFI::Library
-  ffi_lib '{{class.name}}_c'
+  ffi_lib ['{{class.name}}_c',
+           File.dirname(__FILE__) + '/lib{{class.name}}_c.so',
+           File.dirname(__FILE__) + '/lib{{class.name}}_c.dylib' ]
   attach_function :{{class.name}}_dispose, [:pointer], :void
   attach_function :{{class.name}}_error, [], :string
   attach_function :{{class.name}}_clear_error, [], :void 


### PR DESCRIPTION
ffi_lib can be an array of paths, instead of a single string. These are
tried in order, so use the existing string as the first one, and specify
two absolute paths in terms of the directory containing the Ruby script
- one for Linux (.so suffix)
- one for OS X (.dylib suffix).

This fixes issue #39.